### PR TITLE
Add Kahan and Neumaier sums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX = g++
 CPPFLAGS = -g -O3 -Wall
-CXXFLAGS = -std=c++11
+CXXFLAGS = -std=c++17 -msse4.2
 LDLIBS = -lbenchmark -lgtest -lpthread
 
 SYSTEM := $(shell uname -s)

--- a/sum.cc
+++ b/sum.cc
@@ -1,3 +1,4 @@
+#include <array>
 #include <cmath>
 #include <numeric>
 #include <vector>
@@ -5,8 +6,10 @@
 #include <benchmark/benchmark.h>
 #include <gtest/gtest.h>
 
+namespace {
+
 // naive summation suffers from round-off error
-static double sum_naive(const double* value, size_t len) {
+double sum_naive(const double* value, size_t len) {
   double sum = 0;
   for (size_t i = 0; i < len; ++i) {
     sum += value[i];
@@ -15,7 +18,7 @@ static double sum_naive(const double* value, size_t len) {
 }
 
 // recursive pairwise summation with higher precision
-static double sum_pairwise_recur(const double* value, size_t len) {
+double sum_pairwise_recur(const double* value, size_t len) {
   // minimal block size to do divide and conqure
   // smaller value -> better precision, larger value -> better performance
   constexpr int min_block_size = 16;  // same as numpy
@@ -27,7 +30,7 @@ static double sum_pairwise_recur(const double* value, size_t len) {
 }
 
 // non-recursive pariwise summation
-static double sum_pairwise_itera(const double* value, size_t len) {
+double sum_pairwise_itera(const double* value, size_t len) {
   constexpr int min_block_size = 16;
   static_assert(min_block_size > 1, "min_block_size must be greater than 1");
 
@@ -81,39 +84,240 @@ static double sum_pairwise_itera(const double* value, size_t len) {
   return sum[root_level];
 }
 
-static const std::vector<double> GenerateTestData(size_t len) {
+struct KahanSum {
+  double sum = 0;
+  double c = 0;
+
+  KahanSum& operator+=(double v) {
+    double y = v - (std::isnan(c) ? 0 : c);
+    double t = sum + y;
+    c = (t - sum) - y;
+    sum = t;
+    return *this;
+  }
+
+  KahanSum& operator+=(const KahanSum& other) {
+    (*this) += other.sum;
+    (*this) += (std::isnan(other.c) ? 0 : other.c);
+    return *this;
+  }
+
+  double operator()() {
+    return sum;
+  }
+};
+
+double sum_kahan_naive(const double* value, size_t len) {
+  KahanSum sum;
+  for (size_t i = 0; i < len; ++i) {
+    sum += value[i];
+  }
+  return sum();
+}
+
+double sum_kahan_interleaved(const double* value, size_t len) {
+  constexpr int kInterleave = 8;
+
+  std::array<KahanSum, kInterleave> sums;
+
+  size_t i = 0;
+  for (; i < len - kInterleave; i += kInterleave) {
+    for (size_t j = 0; j < kInterleave; ++j) {
+      sums[j] += value[i + j];
+    }
+  }
+  for (; i < len; ++i) {
+    sums[0] += value[i];
+  }
+  for (size_t j = 1; j < kInterleave; ++j) {
+    sums[0] += sums[j];
+  }
+  return sums[0]();
+}
+
+double sum_kahan_blocked(const double* value, size_t len) {
+  // Just like sum_pairwise_itera and sum_pairwise_recur, this trades off
+  // a bit of precision (by allowing for errors to accumulate inside a single
+  // block) in exchange of higher performance.
+  constexpr int kBlockSize = 16;
+  constexpr int kInterleave = 8;
+
+  std::array<KahanSum, kInterleave> sums;
+
+  size_t i = 0;
+  for (; i < len - (kBlockSize * kInterleave); i += (kBlockSize * kInterleave)) {
+    std::array<double, kInterleave> block_sums{};
+    for (size_t j = 0; j < kBlockSize; ++j) {
+      for (size_t k = 0; k < kInterleave; ++k) {
+        block_sums[k] += value[i + j * kInterleave + k];
+      }
+    }
+    for (size_t j = 0; j < kInterleave; ++j) {
+      sums[j] += block_sums[j];
+    }
+  }
+  for (; i < len - kBlockSize; i += kBlockSize) {
+    double block_sum = 0;
+    for (size_t j = 0; j < kBlockSize; ++j) {
+      block_sum += value[i + j];
+    }
+    sums[0] += block_sum;
+  }
+  for (; i < len; ++i) {
+    sums[0] += value[i];
+  }
+  for (size_t j = 1; j < kInterleave; ++j) {
+    sums[0] += sums[j];
+  }
+  return sums[0]();
+}
+
+struct NeumaierSum {
+  double sum = 0;
+  double c = 0;
+
+  NeumaierSum& operator+=(double v) {
+    double t = sum + v;
+    c += (std::abs(sum) >= std::abs(v)) ? (sum - t) + v : (v - t) + sum;
+    sum = t;
+    return *this;
+  }
+
+  NeumaierSum& operator+=(const NeumaierSum& other) {
+    (*this) += other.sum;
+    (*this) += (std::isnan(other.c) ? 0 : other.c);
+    return *this;
+  }
+
+  double operator()() {
+    return sum + (std::isnan(c) ? 0 : c);
+  }
+};
+
+double sum_neumaier_naive(const double* value, size_t len) {
+  NeumaierSum sum;
+  for (size_t i = 0; i < len; ++i) {
+    sum += value[i];
+  }
+  return sum();
+}
+
+double sum_neumaier_interleaved(const double* value, size_t len) {
+  constexpr int kInterleave = 4;
+
+  std::array<NeumaierSum, kInterleave> sums;
+
+  size_t i = 0;
+  for (; i < len - kInterleave; i += kInterleave) {
+    for (size_t j = 0; j < kInterleave; ++j) {
+      sums[j] += value[i + j];
+    }
+  }
+  for (; i < len; ++i) {
+    sums[0] += value[i];
+  }
+  for (size_t j = 1; j < kInterleave; ++j) {
+    sums[0] += sums[j];
+  }
+  return sums[0]();
+}
+
+double sum_neumaier_blocked(const double* value, size_t len) {
+  // Similar to sum_kahan_blocked
+  constexpr int kBlockSize = 16;
+  constexpr int kInterleave = 8;
+
+  std::array<NeumaierSum, kInterleave> sums;
+
+  size_t i = 0;
+  for (; i < len - (kBlockSize * kInterleave); i += (kBlockSize * kInterleave)) {
+    std::array<double, kInterleave> block_sums{};
+    for (size_t j = 0; j < kBlockSize; ++j) {
+      for (size_t k = 0; k < kInterleave; ++k) {
+        block_sums[k] += value[i + j * kInterleave + k];
+      }
+    }
+    for (size_t j = 0; j < kInterleave; ++j) {
+      sums[j] += block_sums[j];
+    }
+  }
+  for (; i < len - kBlockSize; i += kBlockSize) {
+    double block_sum = 0;
+    for (size_t j = 0; j < kBlockSize; ++j) {
+      block_sum += value[i + j];
+    }
+    sums[0] += block_sum;
+  }
+  for (; i < len; ++i) {
+    sums[0] += value[i];
+  }
+  for (size_t j = 1; j < kInterleave; ++j) {
+    sums[0] += sums[j];
+  }
+  return sums[0]();
+}
+
+const std::vector<double> GenerateTestData(size_t len) {
   std::vector<double> v(len);
   std::iota(v.begin(), v.end(), 0);   // 0, 1, 2, ...
   return v;
 }
 
-static void BM_naive(benchmark::State& state) {
+template <typename SumFunc>
+void BenchmarkSummer(benchmark::State& state, SumFunc&& sum_func) {
   const std::vector<double> value = GenerateTestData(state.range(0));
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(sum_naive(value.data(), value.size()));
+    benchmark::DoNotOptimize(sum_func(value.data(), value.size()));
   }
+  state.SetItemsProcessed(state.iterations() * value.size());
 }
 
-static void BM_pairwise_recur(benchmark::State& state) {
-  const std::vector<double> value = GenerateTestData(state.range(0));
-
-  for (auto _ : state) {
-    benchmark::DoNotOptimize(sum_pairwise_recur(value.data(), value.size()));
-  }
+void BM_naive(benchmark::State& state) {
+  BenchmarkSummer(state, sum_naive);
 }
 
-static void BM_pairwise_itera(benchmark::State& state) {
-  const std::vector<double> value = GenerateTestData(state.range(0));
-
-  for (auto _ : state) {
-    benchmark::DoNotOptimize(sum_pairwise_itera(value.data(), value.size()));
-  }
+void BM_pairwise_recur(benchmark::State& state) {
+  BenchmarkSummer(state, sum_pairwise_recur);
 }
 
-BENCHMARK(BM_naive)->Arg(4096)->Arg(65536)->Arg(1 << 20);
-BENCHMARK(BM_pairwise_recur)->Arg(4096)->Arg(65536)->Arg(1 << 20);
-BENCHMARK(BM_pairwise_itera)->Arg(4096)->Arg(65536)->Arg(1 << 20);
+void BM_pairwise_itera(benchmark::State& state) {
+  BenchmarkSummer(state, sum_pairwise_itera);
+}
+
+void BM_kahan_naive(benchmark::State& state) {
+  BenchmarkSummer(state, sum_kahan_naive);
+}
+
+void BM_kahan_interleaved(benchmark::State& state) {
+  BenchmarkSummer(state, sum_kahan_interleaved);
+}
+
+void BM_kahan_blocked(benchmark::State& state) {
+  BenchmarkSummer(state, sum_kahan_blocked);
+}
+
+void BM_neumaier_naive(benchmark::State& state) {
+  BenchmarkSummer(state, sum_neumaier_naive);
+}
+
+void BM_neumaier_interleaved(benchmark::State& state) {
+  BenchmarkSummer(state, sum_neumaier_interleaved);
+}
+
+void BM_neumaier_blocked(benchmark::State& state) {
+  BenchmarkSummer(state, sum_neumaier_blocked);
+}
+
+BENCHMARK(BM_naive)->Arg(128)->Arg(4096)->Arg(65536)->Arg(1 << 20);
+BENCHMARK(BM_pairwise_recur)->Arg(128)->Arg(4096)->Arg(65536)->Arg(1 << 20);
+BENCHMARK(BM_pairwise_itera)->Arg(128)->Arg(4096)->Arg(65536)->Arg(1 << 20);
+BENCHMARK(BM_kahan_naive)->Arg(128)->Arg(4096)->Arg(65536)->Arg(1 << 20);
+BENCHMARK(BM_kahan_interleaved)->Arg(128)->Arg(4096)->Arg(65536)->Arg(1 << 20);
+BENCHMARK(BM_kahan_blocked)->Arg(128)->Arg(4096)->Arg(65536)->Arg(1 << 20);
+BENCHMARK(BM_neumaier_naive)->Arg(128)->Arg(4096)->Arg(65536)->Arg(1 << 20);
+BENCHMARK(BM_neumaier_interleaved)->Arg(128)->Arg(4096)->Arg(65536)->Arg(1 << 20);
+BENCHMARK(BM_neumaier_blocked)->Arg(128)->Arg(4096)->Arg(65536)->Arg(1 << 20);
 
 TEST(Sum, Basic) {
   const std::vector<double> value = GenerateTestData(1000);
@@ -121,6 +325,12 @@ TEST(Sum, Basic) {
   EXPECT_EQ(sum_naive(value.data(), value.size()), sum);
   EXPECT_EQ(sum_pairwise_recur(value.data(), value.size()), sum);
   EXPECT_EQ(sum_pairwise_itera(value.data(), value.size()), sum);
+  EXPECT_EQ(sum_kahan_naive(value.data(), value.size()), sum);
+  EXPECT_EQ(sum_kahan_interleaved(value.data(), value.size()), sum);
+  EXPECT_EQ(sum_kahan_blocked(value.data(), value.size()), sum);
+  EXPECT_EQ(sum_neumaier_naive(value.data(), value.size()), sum);
+  EXPECT_EQ(sum_neumaier_interleaved(value.data(), value.size()), sum);
+  EXPECT_EQ(sum_neumaier_blocked(value.data(), value.size()), sum);
 }
 
 // naive sum fails this test
@@ -132,6 +342,48 @@ TEST(Sum, Roundoff) {
 
   EXPECT_EQ(sum_pairwise_recur(value.data(), value.size()), 2756346749973250);
   EXPECT_EQ(sum_pairwise_itera(value.data(), value.size()), 2756346749973250);
+  EXPECT_EQ(sum_kahan_naive(value.data(), value.size()), 2756346749973250);
+  EXPECT_EQ(sum_kahan_interleaved(value.data(), value.size()), 2756346749973250);
+  EXPECT_EQ(sum_kahan_blocked(value.data(), value.size()), 2756346749973250);
+  EXPECT_EQ(sum_neumaier_naive(value.data(), value.size()), 2756346749973250);
+  EXPECT_EQ(sum_neumaier_interleaved(value.data(), value.size()), 2756346749973250);
+  EXPECT_EQ(sum_neumaier_blocked(value.data(), value.size()), 2756346749973250);
+}
+
+// Only pure Neumaier sums pass this test
+TEST(Sum, Roundoff2) {
+  std::vector<double> value;
+  for (int i = 0; i < 100; ++i) {
+    value.push_back(1);
+    value.push_back(1e100);
+    value.push_back(1);
+    value.push_back(-1e100);
+    value.push_back(1);
+  }
+
+  EXPECT_EQ(sum_neumaier_naive(value.data(), value.size()), 300);
+  EXPECT_EQ(sum_neumaier_interleaved(value.data(), value.size()), 300);
+}
+
+TEST(Sum, NonFinite) {
+  std::vector<double> value;
+  for (int i = 0; i < 100; ++i) {
+    value.push_back(1);
+    value.push_back(HUGE_VAL);
+    value.push_back(1);
+  }
+
+  EXPECT_EQ(sum_naive(value.data(), value.size()), HUGE_VAL);
+  EXPECT_EQ(sum_pairwise_itera(value.data(), value.size()), HUGE_VAL);
+  EXPECT_EQ(sum_pairwise_recur(value.data(), value.size()), HUGE_VAL);
+  EXPECT_EQ(sum_kahan_naive(value.data(), value.size()), HUGE_VAL);
+  EXPECT_EQ(sum_kahan_interleaved(value.data(), value.size()), HUGE_VAL);
+  EXPECT_EQ(sum_kahan_blocked(value.data(), value.size()), HUGE_VAL);
+  EXPECT_EQ(sum_neumaier_naive(value.data(), value.size()), HUGE_VAL);
+  EXPECT_EQ(sum_neumaier_interleaved(value.data(), value.size()), HUGE_VAL);
+  EXPECT_EQ(sum_neumaier_blocked(value.data(), value.size()), HUGE_VAL);
+}
+
 }
 
 // mix test and benchmark, may corrupt argc/argv


### PR DESCRIPTION
Also improve tests.

Benchmark results here (AMD Zen 2 CPU):
```
------------------------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------
BM_naive/128                          64.6 ns         64.6 ns      4334457 items_per_second=1.98084G/s
BM_naive/4096                         2712 ns         2711 ns       103081 items_per_second=1.51087G/s
BM_naive/65536                       43703 ns        43692 ns         6384 items_per_second=1.49995G/s
BM_naive/1048576                    699865 ns       699675 ns          399 items_per_second=1.49866G/s

BM_pairwise_recur/128                 31.8 ns         31.8 ns      8844838 items_per_second=4.03087G/s
BM_pairwise_recur/4096                 758 ns          758 ns       368389 items_per_second=5.40549G/s
BM_pairwise_recur/65536              16563 ns        16559 ns        16877 items_per_second=3.95777G/s
BM_pairwise_recur/1048576           216751 ns       216685 ns         1292 items_per_second=4.83917G/s

BM_pairwise_itera/128                 46.4 ns         46.4 ns      6021105 items_per_second=2.76117G/s
BM_pairwise_itera/4096                 951 ns          951 ns       292941 items_per_second=4.30823G/s
BM_pairwise_itera/65536              14936 ns        14932 ns        18749 items_per_second=4.38883G/s
BM_pairwise_itera/1048576           241553 ns       241472 ns         1157 items_per_second=4.34244G/s

BM_kahan_naive/128                     331 ns          331 ns       834169 items_per_second=386.711M/s
BM_kahan_naive/4096                  10986 ns        10984 ns        25494 items_per_second=372.902M/s
BM_kahan_naive/65536                176013 ns       175968 ns         1592 items_per_second=372.432M/s
BM_kahan_naive/1048576             2814609 ns      2813812 ns           99 items_per_second=372.653M/s

BM_kahan_interleaved/128               124 ns          124 ns      2247509 items_per_second=1.02868G/s
BM_kahan_interleaved/4096             2562 ns         2561 ns       109077 items_per_second=1.59917G/s
BM_kahan_interleaved/65536           40413 ns        40403 ns         6897 items_per_second=1.62206G/s
BM_kahan_interleaved/1048576        648344 ns       648118 ns          430 items_per_second=1.61788G/s

BM_kahan_blocked/128                   106 ns          106 ns      2630563 items_per_second=1.20858G/s
BM_kahan_blocked/4096                  604 ns          603 ns       464253 items_per_second=6.78728G/s
BM_kahan_blocked/65536                8316 ns         8314 ns        33771 items_per_second=7.88238G/s
BM_kahan_blocked/1048576            132038 ns       132002 ns         2123 items_per_second=7.94365G/s

BM_neumaier_naive/128                  175 ns          175 ns      1596966 items_per_second=732.502M/s
BM_neumaier_naive/4096                5735 ns         5734 ns        48687 items_per_second=714.293M/s
BM_neumaier_naive/65536              91955 ns        91930 ns         3043 items_per_second=712.887M/s
BM_neumaier_naive/1048576          1472463 ns      1471991 ns          190 items_per_second=712.352M/s

BM_neumaier_interleaved/128            106 ns          106 ns      2608352 items_per_second=1.203G/s
BM_neumaier_interleaved/4096          3085 ns         3085 ns        91031 items_per_second=1.32785G/s
BM_neumaier_interleaved/65536        40590 ns        40581 ns         5783 items_per_second=1.61493G/s
BM_neumaier_interleaved/1048576     642474 ns       642247 ns          435 items_per_second=1.63267G/s

BM_neumaier_blocked/128               62.2 ns         62.2 ns      4469112 items_per_second=2.05714G/s
BM_neumaier_blocked/4096               600 ns          600 ns       465308 items_per_second=6.82378G/s
BM_neumaier_blocked/65536             9207 ns         9205 ns        30359 items_per_second=7.11968G/s
BM_neumaier_blocked/1048576         145652 ns       145601 ns         1917 items_per_second=7.2017G/s
```